### PR TITLE
fix: health endpoint bypass CORS via path change /health

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -19,13 +19,13 @@ const app = new Hono()
 
 registerOnError(app)
 
-// Mount health & metrics — before CORS so tools like curl work
-app.route('/', healthRouter)
-
 app.use('*', requestId())
 app.use('*', requestLogger())
 app.use('*', metricsMiddleware())
-app.use('*', corsMiddleware)
+app.use('/api/*', corsMiddleware)
+
+// Mount health & metrics — not protected by CORS so monitoring tools work
+app.route('/', healthRouter)
 
 app.use('/api/user/*', withClientId)
 app.use('/api/extract', withClientId)

--- a/apps/api/src/middleware/requestLogger.ts
+++ b/apps/api/src/middleware/requestLogger.ts
@@ -5,7 +5,7 @@ export function requestLogger(): MiddlewareHandler {
   return async (c, next) => {
     const path = c.req.path
 
-    if (path === '/api/health' || path === '/metrics') {
+    if (path === '/health' || path === '/metrics') {
       await next()
       return
     }

--- a/apps/api/src/routes/healthRouter.ts
+++ b/apps/api/src/routes/healthRouter.ts
@@ -4,7 +4,7 @@ import { metricsHandler } from '../middleware/metrics.js'
 
 export const healthRouter = new Hono()
 
-healthRouter.get('/api/health', (c) => {
+healthRouter.get('/health', (c) => {
   return c.json({
     status: 'ok',
     timestamp: new Date().toISOString(),


### PR DESCRIPTION
Health route von /api/health nach /health geändert, corsMiddleware auf /api/* beschränkt.