### PR TITLE
fix: prometheus scrape target host.docker.internal -> api (Linux)

### DIFF
--- a/apps/api/prometheus.yml
+++ b/apps/api/prometheus.yml
@@ -11,7 +11,7 @@ scrape_configs:
   - job_name: source-taster-api
     static_configs:
       - targets:
-          - 'host.docker.internal:8000'
+          - 'api:8000'
 
   - job_name: cadvisor
     static_configs:


### PR DESCRIPTION
host.docker.internal ist Docker Desktop only (Mac/Windows). Auf Linux (Hetzner) via Container-Name api:8000.