### PR TITLE
fix: remove non-matching glob from extension clear script

### DIFF
--- a/apps/extension/package.json
+++ b/apps/extension/package.json
@@ -23,7 +23,7 @@
     "pack:xpi": "cross-env WEB_EXT_ARTIFACTS_DIR=./ web-ext build --source-dir ./extension --filename extension.xpi --overwrite-dest",
     "start:chromium": "web-ext run --source-dir ./extension --target=chromium",
     "start:firefox": "web-ext run --source-dir ./extension --target=firefox-desktop",
-    "clear": "rimraf --glob extension/dist extension/manifest.json extension.*",
+    "clear": "rimraf --glob extension/dist extension/manifest.json",
     "lint": "eslint .",
     "lint:fix": "eslint --fix .",
     "typecheck": "tsc --noEmit",


### PR DESCRIPTION
The `clear` script in the extension package had `extension.*` which doesn't match anything, causing `rimraf` to exit with code 1. This broke the CI build.