### PR TITLE
fix: copy all workspace package.json to Docker deps stage

### DIFF
--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -14,6 +14,8 @@ RUN apt-get update \
   && rm -rf /var/lib/apt/lists/*
 COPY pnpm-lock.yaml pnpm-workspace.yaml package.json ./
 COPY apps/api/package.json apps/api/package.json
+COPY apps/docs/package.json apps/docs/package.json
+COPY apps/extension/package.json apps/extension/package.json
 COPY packages/types/package.json packages/types/package.json
 COPY packages/eslint-config/package.json packages/eslint-config/package.json
 RUN pnpm install --frozen-lockfile


### PR DESCRIPTION
Der Build lädt jedes Mal 625 Dependencies neu herunter (\~4 min), weil der `deps` Stage nur 3 von 6 Workspace-package.json kopiert. Wenn `build` Stage das volle Source-Tree kopiert (`COPY . .`), sieht pnpm auf einmal 6 Projekte und reinstalled alles.\n\n**Fix**: Alle 6 Workspace-package.json bereits im `deps` Stage kopieren → pnpm installiert alle Dependencies sofort, build Stage muss nur noch kompilieren.