### PR TITLE
fix: remove --no-cache aus deploy, git in Dockerfiles

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -53,5 +53,5 @@ jobs:
             cd ${{ secrets.DEPLOY_PATH }}
             git fetch origin main
             git reset --hard origin/main
-            docker compose build --pull --no-cache
+            docker compose build --pull
             docker compose up -d --remove-orphans

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -10,7 +10,7 @@ WORKDIR /app
 FROM base AS deps
 WORKDIR /app
 RUN apt-get update \
-  && apt-get install -y --no-install-recommends ca-certificates build-essential python3 \
+  && apt-get install -y --no-install-recommends ca-certificates build-essential python3 git \
   && rm -rf /var/lib/apt/lists/*
 COPY pnpm-lock.yaml pnpm-workspace.yaml package.json ./
 COPY apps/api/package.json apps/api/package.json

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -14,6 +14,8 @@ RUN apt-get update \
   && rm -rf /var/lib/apt/lists/*
 COPY pnpm-lock.yaml pnpm-workspace.yaml package.json ./
 COPY apps/api/package.json apps/api/package.json
+COPY apps/docs/package.json apps/docs/package.json
+COPY apps/extension/package.json apps/extension/package.json
 COPY packages/types/package.json packages/types/package.json
 COPY packages/eslint-config/package.json packages/eslint-config/package.json
 RUN pnpm install --frozen-lockfile

--- a/apps/docs/Dockerfile
+++ b/apps/docs/Dockerfile
@@ -9,8 +9,13 @@ WORKDIR /app
 
 FROM base AS deps
 WORKDIR /app
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends git \
+  && rm -rf /var/lib/apt/lists/*
 COPY pnpm-lock.yaml pnpm-workspace.yaml package.json ./
 COPY apps/docs/package.json apps/docs/package.json
+COPY apps/extension/package.json apps/extension/package.json
+COPY apps/api/package.json apps/api/package.json
 COPY packages/types/package.json packages/types/package.json
 COPY packages/eslint-config/package.json packages/eslint-config/package.json
 RUN pnpm install --frozen-lockfile


### PR DESCRIPTION
**Problem**: `docker compose build --pull --no-cache` verwirft bei jedem Deploy alle Docker Layer. apt-get + pnpm install + postinstall laufen jedes Mal frisch → ~10-15min Build.\n\n**Fix**:\n- `--no-cache` entfernt → Docker cached Layercache zwischen Deploys → Folge-Builds ~1-2min\n- `git` in beiden Dockerfiles installiert (simple-git-hooks preinstall braucht es)