### PR TITLE
fix: add --all flag to bumpp for workspace version bump

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,7 +57,7 @@ jobs:
           fi
 
       - name: Bump versions
-        run: pnpm bumpp --no-commit --no-push --release "${{ steps.version.outputs.bump }}"
+        run: pnpm bumpp --no-commit --no-push --all --release "${{ steps.version.outputs.bump }}"
 
       - name: Generate changelog
         run: npx conventional-changelog -p conventionalcommits -i CHANGELOG.md -s

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -145,12 +145,30 @@ importers:
         specifier: ^3.5.40
         version: 3.5.40(typescript@5.9.3)
     devDependencies:
+      '@braintree/sanitize-url':
+        specifier: ^7.1.2
+        version: 7.1.2
       '@mermaid-js/mermaid-mindmap':
         specifier: ^9.3.0
         version: 9.3.0
       '@source-taster/eslint-config':
         specifier: workspace:^
         version: link:../../packages/eslint-config
+      cytoscape:
+        specifier: ^3.34.0
+        version: 3.34.0
+      cytoscape-cose-bilkent:
+        specifier: ^4.1.0
+        version: 4.1.0(cytoscape@3.34.0)
+      dagre-d3-es:
+        specifier: ^7.0.14
+        version: 7.0.14
+      dayjs:
+        specifier: ^1.11.21
+        version: 1.11.21
+      debug:
+        specifier: ^4.4.3
+        version: 4.4.3
       eslint:
         specifier: ^9.39.5
         version: 9.39.5(jiti@2.7.0)


### PR DESCRIPTION
Root package.json has no version field (private). --all bumps all workspace packages instead.