### PR TITLE
fix: add version field to root package.json for bumpp

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "source-taster",
   "type": "module",
+  "version": "2.1.3",
   "private": true,
   "packageManager": "pnpm@11.14.0",
   "description": "Browser extension and API for automated academic reference verification. Extracts, searches, and validates sources across 5 databases — detects AI-hallucinated references with 100% accuracy.",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -145,12 +145,30 @@ importers:
         specifier: ^3.5.40
         version: 3.5.40(typescript@5.9.3)
     devDependencies:
+      '@braintree/sanitize-url':
+        specifier: ^7.1.2
+        version: 7.1.2
       '@mermaid-js/mermaid-mindmap':
         specifier: ^9.3.0
         version: 9.3.0
       '@source-taster/eslint-config':
         specifier: workspace:^
         version: link:../../packages/eslint-config
+      cytoscape:
+        specifier: ^3.34.0
+        version: 3.34.0
+      cytoscape-cose-bilkent:
+        specifier: ^4.1.0
+        version: 4.1.0(cytoscape@3.34.0)
+      dagre-d3-es:
+        specifier: ^7.0.14
+        version: 7.0.14
+      dayjs:
+        specifier: ^1.11.21
+        version: 1.11.21
+      debug:
+        specifier: ^4.4.3
+        version: 4.4.3
       eslint:
         specifier: ^9.39.5
         version: 9.39.5(jiti@2.7.0)


### PR DESCRIPTION
bumpp requires a version in the root package.json. Synced with extension's current version 2.1.3.