### PR TITLE
fix: force-push tags and branches in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,9 +69,9 @@ jobs:
           git add -A
           git commit --no-verify -m "chore(release): v${VERSION} [skip ci]"
           git tag "v${VERSION}"
-          git push origin --tags
+          git push origin --tags --force
           git checkout -b "$BRANCH"
-          git push origin "$BRANCH"
+          git push origin "$BRANCH" --force
           gh pr create --base main --head "$BRANCH" \
             --title "chore(release): v${VERSION}" \
             --body "Automated release. Version bumped to v${VERSION}." \

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -145,12 +145,30 @@ importers:
         specifier: ^3.5.40
         version: 3.5.40(typescript@5.9.3)
     devDependencies:
+      '@braintree/sanitize-url':
+        specifier: ^7.1.2
+        version: 7.1.2
       '@mermaid-js/mermaid-mindmap':
         specifier: ^9.3.0
         version: 9.3.0
       '@source-taster/eslint-config':
         specifier: workspace:^
         version: link:../../packages/eslint-config
+      cytoscape:
+        specifier: ^3.34.0
+        version: 3.34.0
+      cytoscape-cose-bilkent:
+        specifier: ^4.1.0
+        version: 4.1.0(cytoscape@3.34.0)
+      dagre-d3-es:
+        specifier: ^7.0.14
+        version: 7.0.14
+      dayjs:
+        specifier: ^1.11.21
+        version: 1.11.21
+      debug:
+        specifier: ^4.4.3
+        version: 4.4.3
       eslint:
         specifier: ^9.39.5
         version: 9.39.5(jiti@2.7.0)


### PR DESCRIPTION
Ensures idempotent retry if a previous run partially failed.