### PR TITLE
fix: Copy eslint-config package.json in Dockerfiles

### DIFF
--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -15,6 +15,7 @@ RUN apt-get update \
 COPY pnpm-lock.yaml pnpm-workspace.yaml package.json ./
 COPY apps/api/package.json apps/api/package.json
 COPY packages/types/package.json packages/types/package.json
+COPY packages/eslint-config/package.json packages/eslint-config/package.json
 RUN pnpm install --no-frozen-lockfile
 
 FROM deps AS build

--- a/apps/api/Dockerfile.dev
+++ b/apps/api/Dockerfile.dev
@@ -7,6 +7,7 @@ COPY apps/api/tsconfig.json apps/api/
 COPY apps/api/package.json apps/api/
 COPY packages/types/package.json packages/types/
 COPY packages/types/tsconfig.json packages/types/
+COPY packages/eslint-config/package.json packages/eslint-config/
 RUN pnpm install --no-frozen-lockfile
 COPY packages/types/ packages/types/
 RUN pnpm --filter @source-taster/types build

--- a/apps/docs/Dockerfile
+++ b/apps/docs/Dockerfile
@@ -14,6 +14,7 @@ RUN apt-get update \
   && rm -rf /var/lib/apt/lists/*
 COPY pnpm-lock.yaml pnpm-workspace.yaml package.json ./
 COPY apps/docs/package.json apps/docs/package.json
+COPY packages/eslint-config/package.json packages/eslint-config/package.json
 RUN pnpm install --no-frozen-lockfile
 
 FROM deps AS build

--- a/apps/landing/Dockerfile
+++ b/apps/landing/Dockerfile
@@ -14,6 +14,7 @@ RUN apt-get update \
   && rm -rf /var/lib/apt/lists/*
 COPY pnpm-lock.yaml pnpm-workspace.yaml package.json ./
 COPY apps/landing/package.json apps/landing/package.json
+COPY packages/eslint-config/package.json packages/eslint-config/package.json
 RUN pnpm install --no-frozen-lockfile
 
 FROM deps AS build


### PR DESCRIPTION
Copy workspace package.json files so pnpm can resolve workspace dependencies when using --no-frozen-lockfile.