### PR TITLE
perf: BuildKit cache mounts for pnpm store, remove --no-cache from deploy

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -123,7 +123,7 @@ jobs:
 
             # build images sequentially (low-memory VPS, 3.7GB RAM)
             for service in landing docs api; do
-              docker compose build --no-cache "$service"
+              docker compose build "$service"
             done
 
             docker compose up -d --remove-orphans

--- a/.gitignore
+++ b/.gitignore
@@ -134,3 +134,4 @@ dist
 
 # Evaluation artifacts
 evaluation/out/
+

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -15,6 +15,7 @@ RUN apt-get update \
 COPY pnpm-lock.yaml pnpm-workspace.yaml package.json ./
 COPY apps/api/package.json apps/api/package.json
 COPY packages/types/package.json packages/types/package.json
+COPY packages/eslint-config/package.json packages/eslint-config/package.json
 RUN pnpm install --no-frozen-lockfile
 
 FROM deps AS build

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -16,7 +16,7 @@ COPY pnpm-lock.yaml pnpm-workspace.yaml package.json ./
 COPY apps/api/package.json apps/api/package.json
 COPY packages/types/package.json packages/types/package.json
 COPY packages/eslint-config/package.json packages/eslint-config/package.json
-RUN pnpm install --no-frozen-lockfile
+RUN --mount=type=cache,id=pnpm,target=/root/.local/share/pnpm/store pnpm install --no-frozen-lockfile
 
 FROM deps AS build
 WORKDIR /app

--- a/apps/api/Dockerfile.dev
+++ b/apps/api/Dockerfile.dev
@@ -8,7 +8,7 @@ COPY apps/api/package.json apps/api/
 COPY packages/types/package.json packages/types/
 COPY packages/types/tsconfig.json packages/types/
 COPY packages/eslint-config/package.json packages/eslint-config/
-RUN pnpm install --no-frozen-lockfile
+RUN --mount=type=cache,id=pnpm,target=/root/.local/share/pnpm/store pnpm install --no-frozen-lockfile
 COPY packages/types/ packages/types/
 RUN pnpm --filter @source-taster/types build
 COPY apps/api/ apps/api/

--- a/apps/api/Dockerfile.dev
+++ b/apps/api/Dockerfile.dev
@@ -7,6 +7,7 @@ COPY apps/api/tsconfig.json apps/api/
 COPY apps/api/package.json apps/api/
 COPY packages/types/package.json packages/types/
 COPY packages/types/tsconfig.json packages/types/
+COPY packages/eslint-config/package.json packages/eslint-config/
 RUN pnpm install --no-frozen-lockfile
 COPY packages/types/ packages/types/
 RUN pnpm --filter @source-taster/types build

--- a/apps/docs/Dockerfile
+++ b/apps/docs/Dockerfile
@@ -15,7 +15,7 @@ RUN apt-get update \
 COPY pnpm-lock.yaml pnpm-workspace.yaml package.json ./
 COPY apps/docs/package.json apps/docs/package.json
 COPY packages/eslint-config/package.json packages/eslint-config/package.json
-RUN pnpm install --no-frozen-lockfile
+RUN --mount=type=cache,id=pnpm,target=/root/.local/share/pnpm/store pnpm install --no-frozen-lockfile
 
 FROM deps AS build
 WORKDIR /app

--- a/apps/docs/Dockerfile
+++ b/apps/docs/Dockerfile
@@ -14,6 +14,7 @@ RUN apt-get update \
   && rm -rf /var/lib/apt/lists/*
 COPY pnpm-lock.yaml pnpm-workspace.yaml package.json ./
 COPY apps/docs/package.json apps/docs/package.json
+COPY packages/eslint-config/package.json packages/eslint-config/package.json
 RUN pnpm install --no-frozen-lockfile
 
 FROM deps AS build

--- a/apps/landing/Dockerfile
+++ b/apps/landing/Dockerfile
@@ -14,6 +14,7 @@ RUN apt-get update \
   && rm -rf /var/lib/apt/lists/*
 COPY pnpm-lock.yaml pnpm-workspace.yaml package.json ./
 COPY apps/landing/package.json apps/landing/package.json
+COPY packages/eslint-config/package.json packages/eslint-config/package.json
 RUN pnpm install --no-frozen-lockfile
 
 FROM deps AS build

--- a/apps/landing/Dockerfile
+++ b/apps/landing/Dockerfile
@@ -15,7 +15,7 @@ RUN apt-get update \
 COPY pnpm-lock.yaml pnpm-workspace.yaml package.json ./
 COPY apps/landing/package.json apps/landing/package.json
 COPY packages/eslint-config/package.json packages/eslint-config/package.json
-RUN pnpm install --no-frozen-lockfile
+RUN --mount=type=cache,id=pnpm,target=/root/.local/share/pnpm/store pnpm install --no-frozen-lockfile
 
 FROM deps AS build
 WORKDIR /app


### PR DESCRIPTION
Optimierungen für schnelleren Server-Deploy:\n\n1. **BuildKit Cache Mounts** — pnpm store wird zwischen Builds gecached . Nach erstem Build werden packages nicht erneut heruntergeladen.\n\n2. ** entfernt** — Docker nutzt jetzt native Layer-Caches. Nur geänderte Layer werden neu gebaut.\n\nErwartung: Zweiter Deploy nur noch ~2-5 Min statt 15-20 Min.