### PR TITLE
fix: use env vars for chrome-webstore-upload-cli v4

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -97,21 +97,16 @@ jobs:
             apps/extension/extension.xpi
           generate_release_notes: true
 
-      - name: Publish to Chrome Web Store
+      - name: Upload to Chrome Web Store
         if: env.VERSION != ''
         continue-on-error: true
         env:
-          CHROME_CLIENT_ID: ${{ secrets.CHROME_CLIENT_ID }}
-          CHROME_CLIENT_SECRET: ${{ secrets.CHROME_CLIENT_SECRET }}
-          CHROME_REFRESH_TOKEN: ${{ secrets.CHROME_REFRESH_TOKEN }}
-          CHROME_EXTENSION_ID: ${{ secrets.CHROME_EXTENSION_ID }}
+          CLIENT_ID: ${{ secrets.CHROME_CLIENT_ID }}
+          CLIENT_SECRET: ${{ secrets.CHROME_CLIENT_SECRET }}
+          REFRESH_TOKEN: ${{ secrets.CHROME_REFRESH_TOKEN }}
+          EXTENSION_ID: ${{ secrets.CHROME_EXTENSION_ID }}
         run: |
-          npx chrome-webstore-upload-cli \
-            --client-id "$CHROME_CLIENT_ID" \
-            --client-secret "$CHROME_CLIENT_SECRET" \
-            --refresh-token "$CHROME_REFRESH_TOKEN" \
-            --extension-id "$CHROME_EXTENSION_ID" \
-            --zip apps/extension/extension.zip
+          npx chrome-webstore-upload upload --source apps/extension/extension.zip
 
       - name: Publish to Firefox Add-ons
         if: env.VERSION != ''

--- a/.gitignore
+++ b/.gitignore
@@ -136,3 +136,4 @@ dist
 evaluation/out/
 
 # cache test
+# chrome store test


### PR DESCRIPTION
chrome-webstore-upload-cli v4 no longer supports CLI flags for credentials — uses CLIENT_ID/CLIENT_SECRET/REFRESH_TOKEN/EXTENSION_ID env vars instead. Also renamed the step to 'Upload' since it uploads a draft without publishing.