### PR TITLE
fix: correct npx syntax for chrome-webstore-upload binary

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -106,7 +106,7 @@ jobs:
           REFRESH_TOKEN: ${{ secrets.CHROME_REFRESH_TOKEN }}
           EXTENSION_ID: ${{ secrets.CHROME_EXTENSION_ID }}
         run: |
-          npx chrome-webstore-upload upload --source apps/extension/extension.zip
+          npx -y -p chrome-webstore-upload-cli chrome-webstore-upload upload --source apps/extension/extension.zip
 
       - name: Publish to Firefox Add-ons
         if: env.VERSION != ''


### PR DESCRIPTION
The npm package is `chrome-webstore-upload-cli` but the binary is `chrome-webstore-upload`. Use `npx -y -p chrome-webstore-upload-cli chrome-webstore-upload`.