### PR TITLE
fix: run pack script explicitly and quote glob

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -106,7 +106,7 @@ jobs:
           REFRESH_TOKEN: ${{ secrets.CHROME_REFRESH_TOKEN }}
           EXTENSION_ID: ${{ secrets.CHROME_EXTENSION_ID }}
         run: |
-          npx chrome-webstore-upload upload --source apps/extension/extension.zip
+          npx -y -p chrome-webstore-upload-cli chrome-webstore-upload upload --source apps/extension/extension.zip
 
       - name: Publish to Firefox Add-ons
         if: env.VERSION != ''

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,7 +87,7 @@ jobs:
       - name: Build extension packages
         run: |
           pnpm build
-          pnpm --filter @source-taster/extension pack
+          pnpm --filter @source-taster/extension run pack
 
       - uses: softprops/action-gh-release@v2
         with:

--- a/apps/extension/package.json
+++ b/apps/extension/package.json
@@ -17,7 +17,7 @@
     "build:background": "vite build --config vite.config.background.mts",
     "build:web": "vite build",
     "build:js": "vite build --config vite.config.content.mts",
-    "pack": "cross-env NODE_ENV=production run-p pack:*",
+    "pack": "cross-env NODE_ENV=production run-p \"pack:*\"",
     "pack:zip": "rimraf extension.zip && jszip-cli add extension/* -o ./extension.zip",
     "pack:crx": "echo 'crx is deprecated – use pack:zip instead'",
     "pack:xpi": "cross-env WEB_EXT_ARTIFACTS_DIR=./ web-ext build --source-dir ./extension --filename extension.xpi --overwrite-dest",


### PR DESCRIPTION
1. `pnpm pack` runs pnpm's built-in pack (creates .tgz) instead of the `pack` npm script → use `pnpm run pack`. This is why extension.zip/xpi were never created in CI (releases had no assets).\n2. Quote `pack:*` glob so npm-run-all receives it literally (zsh fails on unmatched globs).