### PR TITLE
fix: remove stale web_accessible_resources entry

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -105,6 +105,7 @@ jobs:
           CLIENT_SECRET: ${{ secrets.CHROME_CLIENT_SECRET }}
           REFRESH_TOKEN: ${{ secrets.CHROME_REFRESH_TOKEN }}
           EXTENSION_ID: ${{ secrets.CHROME_EXTENSION_ID }}
+          PUBLISHER_ID: ${{ secrets.CHROME_PUBLISHER_ID }}
         run: |
           npx -y -p chrome-webstore-upload-cli chrome-webstore-upload upload --source apps/extension/extension.zip
 
@@ -120,8 +121,7 @@ jobs:
             --channel listed \
             --source-dir ./extension \
             --api-key "$AMO_JWT_ISSUER" \
-            --api-secret "$AMO_JWT_SECRET" \
-            --use-submission-api
+            --api-secret "$AMO_JWT_SECRET"
 
   deploy:
     if: github.actor != 'github-actions[bot]'

--- a/apps/extension/src/manifest.ts
+++ b/apps/extension/src/manifest.ts
@@ -57,12 +57,6 @@ export async function getManifest() {
         ],
       },
     ],
-    web_accessible_resources: [
-      {
-        resources: ['dist/contentScripts/style.css'],
-        matches: ['<all_urls>'],
-      },
-    ],
     content_security_policy: {
       extension_pages: isDev && !isFirefox
         // this is required on dev for Vite script to load


### PR DESCRIPTION
The manifest referenced `dist/contentScripts/style.css` which is never emitted by the content-script build. Chrome Web Store rejected the package as invalid. Removed the stale entry.