### PR TITLE
feat: auto-publish Chrome Web Store releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -109,6 +109,17 @@ jobs:
         run: |
           npx -y -p chrome-webstore-upload-cli chrome-webstore-upload upload --source apps/extension/extension.zip
 
+      - name: Publish to Chrome Web Store
+        if: env.VERSION != ''
+        continue-on-error: true
+        env:
+          CLIENT_ID: ${{ secrets.CHROME_CLIENT_ID }}
+          CLIENT_SECRET: ${{ secrets.CHROME_CLIENT_SECRET }}
+          REFRESH_TOKEN: ${{ secrets.CHROME_REFRESH_TOKEN }}
+          PUBLISHER_ID: ${{ secrets.CHROME_PUBLISHER_ID }}
+        run: |
+          npx -y -p chrome-webstore-upload-cli chrome-webstore-upload publish --extension-id ${{ secrets.CHROME_EXTENSION_ID }}
+
       - name: Publish to Firefox Add-ons
         if: env.VERSION != ''
         continue-on-error: true


### PR DESCRIPTION
Adds a publish step after upload so each release is submitted for review automatically. continue-on-error: true in case manual first submission is required.